### PR TITLE
increased compatibility with python 3

### DIFF
--- a/ZPsycopgDA/db.py
+++ b/ZPsycopgDA/db.py
@@ -201,7 +201,7 @@ class DB(TM, dbi_db.DB):
                     desc = c.description
             self.failures = 0
 
-        except StandardError, err:
+        except StandardError as err:
             self._abort()
             raise err
 


### PR DESCRIPTION
File "/zope4/lib/python3.7/site-packages/Products/ZPsycopgDA/db.py", line 204
    except StandardError, err:
                        ^
SyntaxError: invalid syntax

Just changed to "as", since it works in both python2.7 and python3